### PR TITLE
Fix for Hawk.get(String key, T defaultValue) method

### DIFF
--- a/hawk/src/androidTest/java/com/orhanobut/hawk/HawkTest.java
+++ b/hawk/src/androidTest/java/com/orhanobut/hawk/HawkTest.java
@@ -36,10 +36,29 @@ public class HawkTest extends InstrumentationTestCase {
         assertEquals(true, Hawk.get("tag"));
     }
 
+    public void testBooleanDefault() {
+        assertEquals(Boolean.FALSE, Hawk.get("tag", false)) ;
+    }
+    public void testBooleanNotDefault() {
+        Hawk.put("tag", true);
+        assertNotSame(true, Hawk.get("tag", false));
+    }
+
     public void testChar() {
         char expected = 'a';
         Hawk.put("tag", expected);
         assertEquals(expected, Hawk.get("tag"));
+    }
+
+    public void testCharDefault() {
+        char expected = 'a';
+        assertEquals(Character.valueOf(expected), Hawk.get("tag", expected));
+    }
+
+    public void testCharNotDefault() {
+        char expected = 'a';
+        Hawk.put("tag", expected);
+        assertNotSame(expected, Hawk.get("tag", 'b'));
     }
 
     public void testByte() {
@@ -48,10 +67,32 @@ public class HawkTest extends InstrumentationTestCase {
         assertEquals(expected, Hawk.get("tag"));
     }
 
+    public void testByteDefault() {
+        byte expected = 0;
+        assertEquals(Byte.valueOf(expected), Hawk.get("tag", expected));
+    }
+
+    public void testByteNotDefault() {
+        byte expected = 0;
+        Hawk.put("tag", expected);
+        assertNotSame(expected, Hawk.get("tag", 1));
+    }
+
     public void testShort() {
         short expected = 0;
         Hawk.put("tag", expected);
         assertEquals(expected, Hawk.get("tag"));
+    }
+
+    public void testShortDefault() {
+        short expected = 0;
+        assertEquals(Short.valueOf(expected), Hawk.get("tag", expected));
+    }
+
+    public void testShortNotDefault() {
+        short expected = 0;
+        Hawk.put("tag", expected);
+        assertNotSame(expected, Hawk.get("tag", 1));
     }
 
     public void testInt() {
@@ -60,10 +101,32 @@ public class HawkTest extends InstrumentationTestCase {
         assertEquals(expected, Hawk.get("tag"));
     }
 
+    public void testIntDefault() {
+        int expected = 0;
+        assertEquals(Integer.valueOf(expected), Hawk.get("tag", expected));
+    }
+
+    public void testIntNotDefault() {
+        int expected = 0;
+        Hawk.put("tag", expected);
+        assertNotSame(expected, Hawk.get("tag", 1));
+    }
+
     public void testLong() {
         long expected = 100L;
         Hawk.put("tag", expected);
         assertEquals(expected, Hawk.get("tag"));
+    }
+
+    public void testLongDefault() {
+        long expected = 100L;
+        assertEquals(Long.valueOf(expected), Hawk.get("tag", expected));
+    }
+
+    public void testLongNotDefault() {
+        long expected = 100L;
+        Hawk.put("tag", expected);
+        assertNotSame(expected, Hawk.get("tag", 99L));
     }
 
     public void testFloat() {
@@ -72,10 +135,32 @@ public class HawkTest extends InstrumentationTestCase {
         assertEquals(expected, Hawk.get("tag"));
     }
 
+    public void testFloatDefault() {
+        float expected = 0.1f;
+        assertEquals(expected, Hawk.get("tag", expected));
+    }
+
+    public void testFloatNotDefault() {
+        float expected = 0.1f;
+        Hawk.put("tag", expected);
+        assertNotSame(expected, Hawk.get("tag", 0.9f));
+    }
+
     public void testDouble() {
         double expected = 11;
         Hawk.put("tag", expected);
         assertEquals(expected, Hawk.get("tag"));
+    }
+
+    public void testDoubleDefault() {
+        double expected = 11;
+        assertEquals(expected, Hawk.get("tag", expected));
+    }
+
+    public void testDoubleNotDefault() {
+        double expected = 11;
+        Hawk.put("tag", expected);
+        assertNotSame(expected, Hawk.get("tag", 99));
     }
 
     public void testString() {
@@ -84,11 +169,30 @@ public class HawkTest extends InstrumentationTestCase {
         assertEquals(expected, Hawk.get("tag"));
     }
 
+    public void testStringDefault() {
+        String expected = "test";
+        assertEquals(expected, Hawk.get("tag", expected));
+    }
+
+    public void testStringNotDefault() {
+        String expected = "test";
+        Hawk.put("tag", expected);
+        assertNotSame(expected, Hawk.get("tag", "default"));
+    }
+
     public void testSerializableObject() {
         FooSerializable foo = new FooSerializable();
 
         Hawk.put("tag", foo);
         FooSerializable foo1 = Hawk.get("tag");
+
+        assertNotNull(foo1);
+    }
+
+    public void testSerializableObjectDefault() {
+        FooSerializable foo = new FooSerializable();
+
+        FooSerializable foo1 = Hawk.get("tag", foo);
 
         assertNotNull(foo1);
     }
@@ -102,10 +206,26 @@ public class HawkTest extends InstrumentationTestCase {
         assertNotNull(foo1);
     }
 
+    public void testNotSerializableObjectDefault() {
+        FooNotSerializable foo = new FooNotSerializable();
+
+        FooNotSerializable foo1 = Hawk.get("tag", foo);
+
+        assertNotNull(foo1);
+    }
+
     public void testParcelableObject() {
         FooParcelable foo = new FooParcelable();
         Hawk.put("tag", foo);
         FooParcelable fooParcelable = Hawk.get("tag");
+
+        assertNotNull(fooParcelable);
+    }
+
+    public void testParcelableObjectDefault() {
+        FooParcelable foo = new FooParcelable();
+
+        FooParcelable fooParcelable = Hawk.get("tag", foo);
 
         assertNotNull(fooParcelable);
     }
@@ -122,6 +242,16 @@ public class HawkTest extends InstrumentationTestCase {
         assertNotNull(list1);
     }
 
+    public void testListSerializableDefault() {
+        List<String> list = new ArrayList<>();
+        list.add("foo");
+        list.add("foo");
+
+        List<String> list1 = Hawk.get("tag", list);
+
+        assertNotNull(list1);
+    }
+
     public void testListParcelable() {
         List<FooParcelable> list = new ArrayList<>();
         list.add(new FooParcelable());
@@ -130,6 +260,16 @@ public class HawkTest extends InstrumentationTestCase {
         Hawk.put("tag", list);
 
         List<FooParcelable> list1 = Hawk.get("tag");
+
+        assertNotNull(list1);
+    }
+
+    public void testListParcelableDefault() {
+        List<FooParcelable> list = new ArrayList<>();
+        list.add(new FooParcelable());
+        list.add(new FooParcelable());
+
+        List<FooParcelable> list1 = Hawk.get("tag", list);
 
         assertNotNull(list1);
     }

--- a/hawk/src/main/java/com/orhanobut/hawk/Hawk.java
+++ b/hawk/src/main/java/com/orhanobut/hawk/Hawk.java
@@ -74,17 +74,11 @@ public final class Hawk {
      * @return the saved object
      */
     public static <T> T get(String key, T defaultValue) {
-        String fullText = storage.get(key);
-        T t;
-        try {
-            t = encoder.decode(fullText);
-        } catch (Exception e) {
-            return null;
-        }
+        T t = get(key);
         if (t == null) {
             return defaultValue;
         }
-        return null;
+        return t;
     }
 
     /**


### PR DESCRIPTION
Fixes Hawk.get not returning actual value when default value is provided and adds some tests for related change