### PR TITLE
Avoiding internal getters.

### DIFF
--- a/hawk/src/androidTest/java/com/orhanobut/hawk/DataUtilTest.java
+++ b/hawk/src/androidTest/java/com/orhanobut/hawk/DataUtilTest.java
@@ -50,22 +50,22 @@ public class DataUtilTest extends InstrumentationTestCase {
 
     public void testGetDataInfoShouldBeSerializable() {
         DataInfo info = DataUtil.getDataInfo("String11@asdfjasdf");
-        assertTrue(info.isSerializable());
+        assertTrue(info.isSerializable);
     }
 
     public void testGetDataInfoShouldNotBeSerializable() {
         DataInfo info = DataUtil.getDataInfo("String10@asdfjasdf");
-        assertFalse(info.isSerializable());
+        assertFalse(info.isSerializable);
     }
 
     public void testGetDataInfoShouldBeList() {
         DataInfo info = DataUtil.getDataInfo("String11@asdfjasdf");
-        assertTrue(info.isSerializable());
+        assertTrue(info.isSerializable);
     }
 
     public void testGetDataInfoShouldNotBeList() {
         DataInfo info = DataUtil.getDataInfo("String00@asdfjasdf");
-        assertFalse(info.isSerializable());
+        assertFalse(info.isSerializable);
     }
 
 

--- a/hawk/src/main/java/com/orhanobut/hawk/DataInfo.java
+++ b/hawk/src/main/java/com/orhanobut/hawk/DataInfo.java
@@ -5,10 +5,10 @@ package com.orhanobut.hawk;
  */
 final class DataInfo {
 
-    private final boolean isSerializable;
-    private final boolean isList;
-    private final String cipherText;
-    private final Class clazz;
+    public final boolean isSerializable;
+    public final boolean isList;
+    public final String cipherText;
+    public final Class clazz;
 
     DataInfo(boolean isSerializable, boolean isList, String cipherText, Class clazz) {
         this.isSerializable = isSerializable;
@@ -17,19 +17,4 @@ final class DataInfo {
         this.clazz = clazz;
     }
 
-    boolean isSerializable() {
-        return isSerializable;
-    }
-
-    boolean isList() {
-        return isList;
-    }
-
-    String getCipherText() {
-        return cipherText;
-    }
-
-    Class getClazz() {
-        return clazz;
-    }
 }

--- a/hawk/src/main/java/com/orhanobut/hawk/HawkEncoder.java
+++ b/hawk/src/main/java/com/orhanobut/hawk/HawkEncoder.java
@@ -74,19 +74,19 @@ final class HawkEncoder implements Encoder {
             return null;
         }
         DataInfo info = DataUtil.getDataInfo(value);
-        boolean isList = info.isList();
+        boolean isList = info.isList;
 
-        byte[] bytes = encryption.decrypt(info.getCipherText());
+        byte[] bytes = encryption.decrypt(info.cipherText);
 
         // if the value is not list and serializable, then use the normal deserialize
-        if (!isList && info.isSerializable()) {
+        if (!isList && info.isSerializable) {
             return toSerializable(bytes);
         }
 
         // convert to the string json
         String json = new String(bytes);
 
-        Class<?> type = info.getClazz();
+        Class<?> type = info.clazz;
         if (!isList) {
             return parser.fromJson(json, type);
         }


### PR DESCRIPTION
Since the ivars are final, we can [avoid trivial getters](http://developer.android.com/training/articles/perf-tips.html#GettersSetters) in `DataInfo`.