### PR TITLE
compability aes

### DIFF
--- a/hawk/src/main/java/com/orhanobut/hawk/AesCbcWithIntegrity.java
+++ b/hawk/src/main/java/com/orhanobut/hawk/AesCbcWithIntegrity.java
@@ -58,8 +58,6 @@ import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.PBEKeySpec;
 import javax.crypto.spec.SecretKeySpec;
 
-import static java.util.Arrays.copyOfRange;
-
 /**
  * Simple library for the "right" defaults for AES key generation, encryption,
  * and decryption using 128-bit AES, CBC, PKCS5 padding, and a random 16-byte IV
@@ -74,7 +72,7 @@ final class AesCbcWithIntegrity {
     private static final int PBE_ITERATION_COUNT = 10000;
     private static final int PBE_SALT_LENGTH_BITS = AES_KEY_LENGTH_BITS; // same size as key output
     private static final String PBE_ALGORITHM = "PBKDF2WithHmacSHA1";
-    private static final int BASE64_FLAGS = Base64.DEFAULT | Base64.NO_WRAP;
+    private static final int BASE64_FLAGS = Base64.NO_WRAP;
     private static final AtomicBoolean prngFixed = new AtomicBoolean(false);
     private static final String HMAC_ALGORITHM = "HmacSHA256";
     private static final int HMAC_KEY_LENGTH_BITS = 256;
@@ -207,7 +205,6 @@ final class AesCbcWithIntegrity {
         return Base64.encodeToString(salt, BASE64_FLAGS);
     }
 
-
     /**
      * Creates a random Initialization Vector (IV) of IV_LENGTH_BYTES.
      *
@@ -226,6 +223,21 @@ final class AesCbcWithIntegrity {
         return b;
     }
 
+    /**
+     * Copy the elements from the start to the end
+     *
+     * @param from  the source
+     * @param start the start index to copy
+     * @param end   the end index to finish
+     * @return the new buffer
+     */
+    private static byte[] copyOfRange(byte[] from, int start, int end) {
+        int length = end - start;
+        byte[] result = new byte[length];
+        System.arraycopy(from, start, result, 0, length);
+        return result;
+    }
+    
     /*
      * -----------------------------------------------------------------
      * Encryption


### PR DESCRIPTION
Arrays.copyOf method is introduced in API 9. In order to support API 8, I just put the method as it is.