### PR TITLE
Handling missing credentials.properties file

### DIFF
--- a/maven_push.gradle
+++ b/maven_push.gradle
@@ -17,10 +17,14 @@ def PASSWORD = "";
 afterEvaluate { project ->
     uploadArchives {
         def Properties versionProps = new Properties()
-        versionProps.load(new FileInputStream('credential.properties'))
-        USERNAME = versionProps['USERNAME'];
-        PASSWORD = versionProps['PASSWORD'];
-        
+        try {
+            versionProps.load(new FileInputStream('credential.properties'))
+            USERNAME = versionProps['USERNAME'];
+            PASSWORD = versionProps['PASSWORD'];
+        } catch(FileNotFoundException e) {
+            println 'Failed to find file credential.properties. Maven deploy disabled'
+        }
+
         repositories {
             mavenDeployer {
                 beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }


### PR DESCRIPTION
This file is gitignored and isn't necessary until a maven deploy is required. This code block is invoked on project load by IntelliJ, so handling it here allows the IDE to load the project successfully.

Here's a screenshot of the error occurring. It shows the text from the `FileNotFoundException` in the dialog.

![screen shot 2015-02-26 at 2 40 08 pm](https://cloud.githubusercontent.com/assets/540290/6401451/18ddb4f4-bdc6-11e4-8ae1-e98e2fc3f247.png)
