### PR TITLE
Add Hawk.buildRx()

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 21
-    buildToolsVersion "21.1.2"
+    compileSdkVersion 22
+    buildToolsVersion "22.0.1"
 
     defaultConfig {
         applicationId "com.orhanobut.hawksample"
         minSdkVersion 10
-        targetSdkVersion 21
+        targetSdkVersion 22
         versionCode 1
         versionName "1.0"
     }

--- a/hawk/build.gradle
+++ b/hawk/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.library'
 
 android {
-  compileSdkVersion 21
-  buildToolsVersion "21.1.2"
+  compileSdkVersion 22
+  buildToolsVersion "22.0.1"
 
   defaultConfig {
     minSdkVersion 8
-    targetSdkVersion 21
+    targetSdkVersion 22
   }
 
   lintOptions {

--- a/hawk/src/androidTest/java/com/orhanobut/hawk/HawkRxTest.java
+++ b/hawk/src/androidTest/java/com/orhanobut/hawk/HawkRxTest.java
@@ -4,8 +4,11 @@ import android.content.Context;
 import android.test.InstrumentationTestCase;
 import android.util.Log;
 
+import rx.Observable;
+import rx.Observer;
 import rx.Subscriber;
 import rx.android.schedulers.AndroidSchedulers;
+import rx.functions.Func1;
 import rx.schedulers.Schedulers;
 
 /**
@@ -62,4 +65,36 @@ public class HawkRxTest extends InstrumentationTestCase {
         });
   }
 
+  public void testBuildRx() {
+    Hawk.init(context)
+        .buildRx()
+        .concatMap(new Func1<Boolean, Observable<Boolean>>() {
+          @Override
+          public Observable<Boolean> call(Boolean aBoolean) {
+            return Hawk.putObservable(KEY, "hawk");
+          }
+        })
+        .concatMap(new Func1<Boolean, Observable<String>>() {
+          @Override
+          public Observable<String> call(Boolean aBoolean) {
+            return Hawk.getObservable(KEY);
+          }
+        })
+        .subscribe(new Observer<String>() {
+          @Override
+          public void onCompleted() {
+            assertTrue(true);
+          }
+
+          @Override
+          public void onError(Throwable throwable) {
+            assertTrue(false);
+          }
+
+          @Override
+          public void onNext(String storedValue) {
+            assertEquals(storedValue, "hawk");
+          }
+        });
+  }
 }

--- a/hawk/src/main/java/com/orhanobut/hawk/Hawk.java
+++ b/hawk/src/main/java/com/orhanobut/hawk/Hawk.java
@@ -59,7 +59,7 @@ public final class Hawk {
    * @return Observable<Boolean>
    */
   public static <T> Observable<Boolean> putObservable(final String key, final T value) {
-    checkRx();
+    Utils.checkRx();
     return Observable.create(new Observable.OnSubscribe<Boolean>() {
       @Override
       public void call(Subscriber<? super Boolean> subscriber) {
@@ -76,13 +76,6 @@ public final class Hawk {
         }
       }
     });
-  }
-
-  private static void checkRx() {
-    if (!Utils.hasRxJavaOnClasspath()) {
-      throw new NoClassDefFoundError("RxJava is not on classpath, " +
-          "make sure that you have it in your dependencies");
-    }
   }
 
   /**
@@ -168,7 +161,7 @@ public final class Hawk {
    * @return Observable<T>
    */
   public static <T> Observable<T> getObservable(String key) {
-    checkRx();
+    Utils.checkRx();
     return getObservable(key, null);
   }
 
@@ -182,7 +175,7 @@ public final class Hawk {
    * @return Observable</T>
    */
   public static <T> Observable<T> getObservable(final String key, final T defaultValue) {
-    checkRx();
+    Utils.checkRx();
     return Observable.create(new Observable.OnSubscribe<T>() {
       @Override
       public void call(Subscriber<? super T> subscriber) {

--- a/hawk/src/main/java/com/orhanobut/hawk/HawkBuilder.java
+++ b/hawk/src/main/java/com/orhanobut/hawk/HawkBuilder.java
@@ -1,10 +1,16 @@
 package com.orhanobut.hawk;
 
+import com.google.gson.Gson;
+
 import android.content.Context;
 import android.os.Handler;
 import android.text.TextUtils;
 
-import com.google.gson.Gson;
+import rx.Observable;
+import rx.Subscriber;
+import rx.android.schedulers.AndroidSchedulers;
+import rx.functions.Func0;
+import rx.schedulers.Schedulers;
 
 /**
  * @author Orhan Obut
@@ -196,4 +202,23 @@ public class HawkBuilder {
 
     void onFail(Exception e);
   }
+    public Observable<Boolean> buildRx() {
+        return Observable.defer(new Func0<Observable<Boolean>>() {
+            @Override
+            public Observable<Boolean> call() {
+                return Observable.create(new Observable.OnSubscribe<Boolean>() {
+                    @Override
+                    public void call(Subscriber<? super Boolean> subscriber) {
+                        try {
+                            startBuild();
+                            subscriber.onNext(true);
+                            subscriber.onCompleted();
+                        } catch (Exception e) {
+                            subscriber.onError(e);
+                        }
+                    }
+                });
+            }
+        }).subscribeOn(Schedulers.io()).observeOn(AndroidSchedulers.mainThread());
+    }
 }

--- a/hawk/src/main/java/com/orhanobut/hawk/HawkBuilder.java
+++ b/hawk/src/main/java/com/orhanobut/hawk/HawkBuilder.java
@@ -33,13 +33,21 @@ public class HawkBuilder {
   private static final String KEY_NO_CRYPTO = "dfsklj2342nasdfoasdfcrpknasdf";
 
   private Context context;
+
   private EncryptionMethod encryptionMethod;
+
   private String password;
+
   private LogLevel logLevel;
+
   private Storage cryptoStorage;
+
   private Encoder encoder;
+
   private Parser parser;
+
   private Encryption encryption;
+
   private Callback callback;
 
   public enum EncryptionMethod {
@@ -198,27 +206,30 @@ public class HawkBuilder {
    * onFail function will be called when action fails due to a reason
    */
   public interface Callback {
+
     void onSuccess();
 
     void onFail(Exception e);
   }
-    public Observable<Boolean> buildRx() {
-        return Observable.defer(new Func0<Observable<Boolean>>() {
-            @Override
-            public Observable<Boolean> call() {
-                return Observable.create(new Observable.OnSubscribe<Boolean>() {
-                    @Override
-                    public void call(Subscriber<? super Boolean> subscriber) {
-                        try {
-                            startBuild();
-                            subscriber.onNext(true);
-                            subscriber.onCompleted();
-                        } catch (Exception e) {
-                            subscriber.onError(e);
-                        }
-                    }
-                });
+
+  public Observable<Boolean> buildRx() {
+    Utils.checkRx();
+    return Observable.defer(new Func0<Observable<Boolean>>() {
+      @Override
+      public Observable<Boolean> call() {
+        return Observable.create(new Observable.OnSubscribe<Boolean>() {
+          @Override
+          public void call(Subscriber<? super Boolean> subscriber) {
+            try {
+              startBuild();
+              subscriber.onNext(true);
+              subscriber.onCompleted();
+            } catch (Exception e) {
+              subscriber.onError(e);
             }
-        }).subscribeOn(Schedulers.io()).observeOn(AndroidSchedulers.mainThread());
-    }
+          }
+        });
+      }
+    }).subscribeOn(Schedulers.io()).observeOn(AndroidSchedulers.mainThread());
+  }
 }

--- a/hawk/src/main/java/com/orhanobut/hawk/HawkBuilder.java
+++ b/hawk/src/main/java/com/orhanobut/hawk/HawkBuilder.java
@@ -1,11 +1,9 @@
 package com.orhanobut.hawk;
 
 import com.google.gson.Gson;
-
 import android.content.Context;
 import android.os.Handler;
 import android.text.TextUtils;
-
 import rx.Observable;
 import rx.Subscriber;
 import rx.android.schedulers.AndroidSchedulers;
@@ -31,23 +29,15 @@ public class HawkBuilder {
    * Key to store if the device does not support crypto
    */
   private static final String KEY_NO_CRYPTO = "dfsklj2342nasdfoasdfcrpknasdf";
-
+  
   private Context context;
-
   private EncryptionMethod encryptionMethod;
-
   private String password;
-
   private LogLevel logLevel;
-
   private Storage cryptoStorage;
-
   private Encoder encoder;
-
   private Parser parser;
-
   private Encryption encryption;
-
   private Callback callback;
 
   public enum EncryptionMethod {

--- a/hawk/src/main/java/com/orhanobut/hawk/Utils.java
+++ b/hawk/src/main/java/com/orhanobut/hawk/Utils.java
@@ -17,4 +17,11 @@ final class Utils {
   private Utils() {
     //no instance
   }
+
+  public static void checkRx() {
+    if (!hasRxJavaOnClasspath()) {
+      throw new NoClassDefFoundError("RxJava is not on classpath, " +
+          "make sure that you have it in your dependencies");
+    }
+  }
 }


### PR DESCRIPTION
StrictMode showed that `.build()` was doing a lot of work on the main thread, even with the callback setup. I tried to wrap the callback with Rx, but I was having issue with `Schedulers`, `Looper`, `Handler` and so on.
I have just created a new method that wraps the synchronous `.startbuild()`, and exposes an `Observable` version of `build()`.