### PR TITLE
Changed the string being used for salting Hawk entries when encryption is not available

### DIFF
--- a/app/src/main/java/com/orhanobut/hawksample/MainActivity.java
+++ b/app/src/main/java/com/orhanobut/hawksample/MainActivity.java
@@ -79,7 +79,9 @@ public class MainActivity extends Activity {
         .setCallback(new HawkBuilder.Callback() {
           @Override
           public void onSuccess() {
-
+            Hawk.put("joda", new DateTime());
+            DateTime dateTime = Hawk.get("joda");
+            testRx();
           }
 
           @Override
@@ -87,11 +89,7 @@ public class MainActivity extends Activity {
 
           }
         })
-        .build();
-    testRx();
-
-    Hawk.put("joda", new DateTime());
-    DateTime dateTime = Hawk.get("joda");
+            .build();
   }
 
   private void testRx() {

--- a/hawk/src/main/java/com/orhanobut/hawk/HawkBuilder.java
+++ b/hawk/src/main/java/com/orhanobut/hawk/HawkBuilder.java
@@ -6,6 +6,8 @@ import android.text.TextUtils;
 
 import com.google.gson.Gson;
 
+import java.util.UUID;
+
 import rx.Observable;
 import rx.Subscriber;
 import rx.android.schedulers.AndroidSchedulers;
@@ -30,7 +32,7 @@ public class HawkBuilder {
   /**
    * Key to store if the device does not support crypto
    */
-  private static final String KEY_NO_CRYPTO = "dfsklj2342nasdfoasdfcrpknasdf";
+  private static final String KEY_NO_CRYPTO = UUID.randomUUID().toString();
 
   private Context context;
   private EncryptionMethod encryptionMethod;


### PR DESCRIPTION
The original intent of this fork was to change the string used for salting the Hawk entries when encryption is not available on the device. This is my first pull request, so any feedback is definitely appreciated. 

In place of the hard-coded string, which will always be a known value, I decided to use the UUID.getRandom.toString() method to generate the string instead. 

There are two reasons why I feel this is a better option:
1.) From a security aspect, even if the UUID.getRandom() method isn't perfectly random, it is much unpredictable than a hard-coded string.
2.) The length of the string used for salting is increased from 29 to 36.

---------------------------------------------------

I also made some small code tweaks in MainActivity.java to prevent a NullPointerException being thrown caused by attempting to store key/value pairs using Hawk before it has finished initalizing.

---------------------------------------------------

From the brief benchmarking I ran on a Galaxy S4, there was only an average increase of ~60ms from changing the hard-coded string to using UUID.getRandom(). See below for the results of the two trials I ran with the original hardcoded string, as well as the string generated via UUID.getRandom(). 

Hard-coded String

Trial 1
Hawk init with password : 31.494139
init: Prefs: 35.064695    Hawk : 31.494139
int put : Pref : 9.063722  -- Hawk : 40.344238
String put : Pref : 10.314942  -- Hawk : 11.230469
List<T> put : Pref : 27.709961  -- Hawk : 25.909424
List<String> put : Pref : 24.688721  -- Hawk : 18.676756
T put : Pref : 13.549806  -- Hawk : 6.591796
Map<String,String> put : Pref : 17.364501  -- Hawk : 13.885498
Set<String> put : Pref : 14.160156  -- Hawk : 7.934571
int get : Pref : 0.0  -- Hawk : 2.471924
String get : Pref : 0.0  -- Hawk : 0.183106
List<T> get : Pref : 13.000487  -- Hawk : 34.027101
List<String> get : Pref : 5.065917  -- Hawk : 8.239746
Object get : Pref : 0.152588  -- Hawk : 0.213623
Map<String,String> get : Pref : 2.716065  -- Hawk : 4.455566
Set<String> get : Pref : 2.319336  -- Hawk : 3.14331
int remove : Pref : 0.0  -- Hawk : 9.094239
Total - 206.665036 (ms)

Trial 2
Hawk init with password : 34.667969
init: Prefs: 39.184571    Hawk : 34.667969
int put : Pref : 10.5896  -- Hawk : 47.76001
String put : Pref : 16.693114  -- Hawk : 9.796143
List<T> put : Pref : 33.233643  -- Hawk : 22.67456
List<String> put : Pref : 11.199951  -- Hawk : 10.101319
T put : Pref : 8.94165  -- Hawk : 6.225587
Map<String,String> put : Pref : 13.48877  -- Hawk : 13.275146
Set<String> put : Pref : 10.406493  -- Hawk : 7.476807
int get : Pref : 0.0  -- Hawk : 2.532958
String get : Pref : 0.030517  -- Hawk : 0.24414
List<T> get : Pref : 8.758546  -- Hawk : 32.379152
List<String> get : Pref : 4.760742  -- Hawk : 7.659912
Object get : Pref : 0.183106  -- Hawk : 0.213623
Map<String,String> get : Pref : 2.624511  -- Hawk : 4.119872
Set<String> get : Pref : 2.288818  -- Hawk : 3.02124
int remove : Pref : 0.0  -- Hawk : 8.697509
Total - 195.052001 (ms)

-----------------------------------------

UUID.getRandom()

Trial 1
Hawk init with password : 57.73926
init: Prefs: 60.88257    Hawk : 57.73926
int put : Pref : 7.720947  -- Hawk : 55.480958
String put : Pref : 10.284423  -- Hawk : 10.803224
List<T> put : Pref : 25.848389  -- Hawk : 21.057129
List<String> put : Pref : 15.747072  -- Hawk : 9.246827
T put : Pref : 10.437011  -- Hawk : 8.117676
Map<String,String> put : Pref : 18.737794  -- Hawk : 13.580322
Set<String> put : Pref : 12.237548  -- Hawk : 10.406494
int get : Pref : 0.0  -- Hawk : 2.868652
String get : Pref : 0.0  -- Hawk : 0.213623
List<T> get : Pref : 12.420654  -- Hawk : 43.090823
List<String> get : Pref : 6.072998  -- Hawk : 9.826661
Object get : Pref : 0.183106  -- Hawk : 0.24414
Map<String,String> get : Pref : 2.685547  -- Hawk : 5.187988
Set<String> get : Pref : 2.593994  -- Hawk : 3.265381
int remove : Pref : 0.030518  -- Hawk : 10.467529
Total - 243.621831 (ms)

Trial 2
Hawk init with password : 79.956054
init: Prefs: 83.343505    Hawk : 79.956054
int put : Pref : 13.580323  -- Hawk : 54.840086
String put : Pref : 9.246826  -- Hawk : 12.145996
List<T> put : Pref : 22.613524  -- Hawk : 20.935059
List<String> put : Pref : 13.214112  -- Hawk : 12.786865
T put : Pref : 7.873535  -- Hawk : 10.34546
Map<String,String> put : Pref : 12.176515  -- Hawk : 14.160156
Set<String> put : Pref : 12.054444  -- Hawk : 9.552003
int get : Pref : 0.030518  -- Hawk : 2.441407
String get : Pref : 0.0  -- Hawk : 0.213623
List<T> get : Pref : 9.490967  -- Hawk : 34.820556
List<String> get : Pref : 4.943848  -- Hawk : 7.904053
Object get : Pref : 0.183106  -- Hawk : 0.244141
Map<String,String> get : Pref : 2.65503  -- Hawk : 4.516602
Set<String> get : Pref : 2.868653  -- Hawk : 3.387452
int remove : Pref : 0.030517  -- Hawk : 8.483887
Total - 274.261473

-----------------------------------------

Averages
(Hard-coded String) - 200.8585185
(UUID.getRandom()) - 258.941652

The benchmarking system I used was adapted from the commented out code in the HawkBuilder.onCreate()

    final long start = System.nanoTime();
    Hawk.init(this)
        .setEncryptionMethod(HawkBuilder.EncryptionMethod.HIGHEST)
        .setPassword("password")
        .setStorage(HawkBuilder.newSharedPrefStorage(this))
        .setLogLevel(LogLevel.FULL)
        .setCallback(new HawkBuilder.Callback() {
          @Override
          public void onSuccess() {
            long end = System.nanoTime();

            double resultHawk = getTime(start, end);
            log("Hawk init with password : " + resultHawk);

            prefs = getSharedPreferences("BENCHARMK", MODE_PRIVATE);
            editor = prefs.edit();
            end = System.nanoTime();
            double resultPref = getTime(start, end);
            log("init: Prefs: " + resultPref + "    Hawk : " + resultHawk);


            benchmarkPrimitivePut();
            benchmarkStringPut();
            benchmarkListObjectPut();
            benchmarkListStringPut();
            benchmarkObjectPut();
            benchmarkMapPut();
            benchmarkSetPut();

            benchmarkPrimitiveGet();
            benchmarkStringGet();
            benchmarkListObjectGet();
            benchmarkListStringGet();
            benchmarkObjectGet();
            benchmarkMapGet();
            benchmarkSetGet();

            benchmarkDelete();
          }

          @Override
          public void onFail(Exception e) {

          }
        })
            .build();


