### PR TITLE
Added setParser() to HawkBuilder

### DIFF
--- a/hawk/src/main/java/com/orhanobut/hawk/HawkBuilder.java
+++ b/hawk/src/main/java/com/orhanobut/hawk/HawkBuilder.java
@@ -81,6 +81,11 @@ public class HawkBuilder {
     return this;
   }
 
+  public HawkBuilder setParser(Parser parser) {
+    this.parser = parser;
+    return this;
+  }
+
   public Context getContext() {
     return context;
   }


### PR DESCRIPTION
Implementation to use a different parser for de-/serialization which was curiously not possible until now.