### PR TITLE
Rx samples: fix subscribeOn/observeOn operators usage.

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,8 +112,8 @@ Observable<Boolean> result = Hawk.putObservable(key, T); // Returns the result a
 example usage
 ```java
 Hawk.putObservable(KEY, new Foo())
-    .observeOn(Schedulers.io())
-    .subscribeOn(AndroidSchedulers.mainThread())
+    .subscribeOn(Schedulers.computation())
+    .observeOn(AndroidSchedulers.mainThread())
     .subscribe(new Subscriber<Boolean>() {
       @Override
       public void onCompleted() {
@@ -153,8 +153,8 @@ Observable<T> result = Hawk.getObservable(key, T);
 example usage
 ```java
 Hawk.<Foo>getObservable(KEY)
-    .observeOn(Schedulers.io())
-    .subscribeOn(AndroidSchedulers.mainThread())
+    .subscribeOn(Schedulers.computation())
+    .observeOn(AndroidSchedulers.mainThread())
     .subscribe(new Subscriber<Foo>() {
       @Override
       public void onCompleted() {


### PR DESCRIPTION
Seems like Rx samples contain a common mistake about `subscribeOn` / `observeOn` operators usage.

[subscribeOn] (http://reactivex.io/documentation/operators/subscribeon.html) defines where `OnSubscribe` function will be invoked (where to start emitting items) and [observeOn] (http://reactivex.io/documentation/operators/observeon.html) defines where we want to observe (receive) items.
Plus, computation [should be used] (http://reactivex.io/documentation/scheduler.html) instead of I/O.