### PR TITLE
Prevent NPE if log was called without a message

### DIFF
--- a/hawk/src/main/java/com/orhanobut/hawk/Logger.java
+++ b/hawk/src/main/java/com/orhanobut/hawk/Logger.java
@@ -46,7 +46,11 @@ final class Logger {
     if (logLevel == LogLevel.NONE) {
       return;
     }
-    int length = message.length();
+    int length = message != null ? message.length() : 0;
+    if (length == 0 && throwable == null) {
+      return;
+    }
+
     if (length <= CHUNK_SIZE) {
       logChunk(logType, message, throwable);
       return;


### PR DESCRIPTION
We had some exception with a null message come up in some obscure situation and the logging couldn't really cope with that. So here's a suggested fix.