### PR TITLE
Add consumer proguard configuration

### DIFF
--- a/hawk/build.gradle
+++ b/hawk/build.gradle
@@ -6,6 +6,7 @@ android {
 
   defaultConfig {
     minSdkVersion rootProject.ext.minSdkVersion
+    consumerProguardFiles 'proguard-rules.pro'
     testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
   }
 

--- a/hawk/proguard-rules.pro
+++ b/hawk/proguard-rules.pro
@@ -1,0 +1,29 @@
+# Gson
+
+# Gson uses generic type information stored in a class file when working with fields. Proguard
+# removes such information by default, so configure it to keep all of it.
+-keepattributes Signature
+
+# For using GSON @Expose annotation
+-keepattributes *Annotation*
+
+# Gson specific classes
+-keep class sun.misc.Unsafe { *; }
+
+# Facebook Conceal
+
+# Keep our interfaces so they can be used by other ProGuard rules.
+# See http://sourceforge.net/p/proguard/bugs/466/
+-keep,allowobfuscation @interface com.facebook.crypto.proguard.annotations.DoNotStrip
+-keep,allowobfuscation @interface com.facebook.crypto.proguard.annotations.KeepGettersAndSetters
+
+# Do not strip any method/class that is annotated with @DoNotStrip
+-keep @com.facebook.crypto.proguard.annotations.DoNotStrip class *
+-keepclassmembers class * {
+    @com.facebook.crypto.proguard.annotations.DoNotStrip *;
+}
+
+-keepclassmembers @com.facebook.crypto.proguard.annotations.KeepGettersAndSetters class * {
+  void set*(***);
+  *** get*();
+}

--- a/hawk/proguard-rules.pro
+++ b/hawk/proguard-rules.pro
@@ -7,6 +7,9 @@
 # For using GSON @Expose annotation
 -keepattributes *Annotation*
 
+# https://github.com/orhanobut/hawk/issues/143
+-keepattributes EnclosingMethod
+
 # Gson specific classes
 -keep class sun.misc.Unsafe { *; }
 


### PR DESCRIPTION
This adds basically the Gson and Facebook Conceal proguard configurations, found [here](https://github.com/google/gson/blob/master/examples/android-proguard-example/proguard.cfg) and [here](https://github.com/facebook/conceal/blob/master/proguard_annotations.pro).

I tested it with the benchmark project and `minifyEnabled`.