### PR TITLE
Update dependencies and tools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ android:
   components:
     - tools
     - platform-tools
-    - build-tools-24.0.1
+    - build-tools-24.0.2
     - android-24
     - extra-android-m2repository
     - sys-img-armeabi-v7a-android-18

--- a/benchmark/build.gradle
+++ b/benchmark/build.gradle
@@ -22,7 +22,7 @@ android {
 dependencies {
   compile fileTree(dir: 'libs', include: ['*.jar'])
   testCompile 'junit:junit:4.12'
-  compile 'com.android.support:appcompat-v7:24.2.0'
+  compile 'com.android.support:appcompat-v7:24.2.1'
 
   compile project(':hawk')
 }

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ subprojects { project ->
       mavenCentral()
     }
     dependencies {
-      classpath 'com.android.tools.build:gradle:2.1.3'
+      classpath 'com.android.tools.build:gradle:2.2.0'
     }
   }
 
@@ -39,14 +39,14 @@ ext {
   minSdkVersion = 10
   targetSdkVersion = 24
   compileSdkVersion = 24
-  buildToolsVersion = '24.0.1'
+  buildToolsVersion = '24.0.2'
   sourceCompatibilityVersion = JavaVersion.VERSION_1_7
   targetCompatibilityVersion = JavaVersion.VERSION_1_7
 }
 
 ext.deps = [
     gson          : 'com.google.code.gson:gson:2.4',
-    conceal       : 'com.facebook.conceal:conceal:1.1.2@aar',
+    conceal       : 'com.facebook.conceal:conceal:1.1.3@aar',
 
     // Test dependencies
     junit         : 'junit:junit:4.12',

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ subprojects { project ->
       mavenCentral()
     }
     dependencies {
-      classpath 'com.android.tools.build:gradle:2.2.0'
+      classpath 'com.android.tools.build:gradle:2.1.3'
     }
   }
 


### PR DESCRIPTION
This includes:

 - `Build tools` (24.0.1 -> 24.0.2)
 - `Support lib` (24.2.0 -> 24.2.1)
 - `Conceal` (1.1.2 -> 1.1.3)

Especially the update for `Conceal` is important as it drastically [reduces app size](https://github.com/facebook/conceal/issues/155#issuecomment-248400391).
I made a release build of the `benchmark` project (with `Proguard`) and the result were as follows:

Before this commit: 3.3MB
After this commit: 1.2MB