### PR TITLE
* Refactoring constructors to allow subclasses differing KeyChain/Cry…

### DIFF
--- a/hawk/src/main/java/com/orhanobut/hawk/ConcealEncryption.java
+++ b/hawk/src/main/java/com/orhanobut/hawk/ConcealEncryption.java
@@ -10,7 +10,7 @@ import com.facebook.crypto.CryptoConfig;
 import com.facebook.crypto.Entity;
 import com.facebook.crypto.keychain.KeyChain;
 
-class ConcealEncryption implements Encryption {
+public class ConcealEncryption implements Encryption {
 
   private final Crypto crypto;
 

--- a/hawk/src/main/java/com/orhanobut/hawk/ConcealEncryption.java
+++ b/hawk/src/main/java/com/orhanobut/hawk/ConcealEncryption.java
@@ -8,14 +8,22 @@ import com.facebook.android.crypto.keychain.SharedPrefsBackedKeyChain;
 import com.facebook.crypto.Crypto;
 import com.facebook.crypto.CryptoConfig;
 import com.facebook.crypto.Entity;
+import com.facebook.crypto.keychain.KeyChain;
 
 class ConcealEncryption implements Encryption {
 
   private final Crypto crypto;
 
   public ConcealEncryption(Context context) {
-    SharedPrefsBackedKeyChain keyChain = new SharedPrefsBackedKeyChain(context, CryptoConfig.KEY_256);
-    crypto = AndroidConceal.get().createDefaultCrypto(keyChain);
+    this(new SharedPrefsBackedKeyChain(context, CryptoConfig.KEY_256));
+  }
+
+  protected ConcealEncryption(KeyChain keyChain) {
+    this(AndroidConceal.get().createDefaultCrypto(keyChain));
+  }
+
+  protected ConcealEncryption(Crypto crypto) {
+    this.crypto = crypto;
   }
 
   @Override public boolean init() {


### PR DESCRIPTION
…pto implementations.

Updating `ConcealEncryption` to allow subclasses the ability to specify different `KeyChain` or `Crypto` implementations.  Our use case is that we need to access encrypted/decrypted values across multiple processes.  However the default `SharedPrefsBackedKeyChain` will not work across multiple processes (see https://developer.android.com/reference/android/content/SharedPreferences.html).  We have created our own `KeyChain` but want to leverage the logic within `ConcealEncryption` and so have made these changes to allow this.