### PR TITLE
Bump conceal to version 2.0.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ ext {
 
 ext.deps = [
     gson          : 'com.google.code.gson:gson:2.8.2',
-    conceal       : 'com.facebook.conceal:conceal:1.1.3@aar',
+    conceal       : 'com.facebook.conceal:conceal:2.0.2',
 
     // Test dependencies
     junit         : 'junit:junit:4.12',

--- a/hawk/src/androidTest/java/com/orhanobut/hawk/ConcealEncryptionTest.kt
+++ b/hawk/src/androidTest/java/com/orhanobut/hawk/ConcealEncryptionTest.kt
@@ -2,6 +2,7 @@ package com.orhanobut.hawk
 
 import android.support.test.InstrumentationRegistry
 import android.support.test.runner.AndroidJUnit4
+import com.facebook.soloader.SoLoader
 
 import org.junit.Before
 import org.junit.Test
@@ -16,6 +17,10 @@ class ConcealEncryptionTest {
 
   @Before fun setup() {
     encryption = ConcealEncryption(InstrumentationRegistry.getContext())
+  }
+
+  @Before fun prepareSo() {
+    SoLoader.init(InstrumentationRegistry.getContext(), false)
   }
 
   @Test fun init() {

--- a/hawk/src/androidTest/java/com/orhanobut/hawk/ConcealTest.kt
+++ b/hawk/src/androidTest/java/com/orhanobut/hawk/ConcealTest.kt
@@ -7,6 +7,7 @@ import com.facebook.android.crypto.keychain.SharedPrefsBackedKeyChain
 import com.facebook.crypto.Crypto
 import com.facebook.crypto.CryptoConfig
 import com.facebook.crypto.Entity
+import com.facebook.soloader.SoLoader
 import com.google.common.truth.Truth.assertThat
 import org.junit.Before
 import org.junit.Test
@@ -18,9 +19,15 @@ class ConcealTest {
   private lateinit var crypto: Crypto
 
   @Before fun setup() {
+    SoLoader.init(InstrumentationRegistry.getContext(), false)
+
     val context = InstrumentationRegistry.getContext()
     val keyChain = SharedPrefsBackedKeyChain(context, CryptoConfig.KEY_256)
     crypto = AndroidConceal.get().createDefaultCrypto(keyChain)
+  }
+
+  @Before fun prepareSo() {
+    SoLoader.init(InstrumentationRegistry.getContext(), false)
   }
 
   @Test fun cryptoIsAvailable() {


### PR DESCRIPTION
According to this issue https://github.com/orhanobut/hawk/issues/233, we are not able to be 64 bits eligible, so I update conceal to version 2.0.2

https://github.com/facebook/conceal/releases

Here is the benchmark running on a `Nexus 5x API 29`

```
com.orhanobut.benchmark D/HAWK: Hawk.init -> Encryption : NoEncryption
com.orhanobut.benchmark I/System.out: Hawk.init: 38ms
com.orhanobut.benchmark D/HAWK: Hawk.put -> key: key, value: value
com.orhanobut.benchmark D/HAWK: Hawk.put -> Converted to "value"
com.orhanobut.benchmark D/HAWK: Hawk.put -> Encrypted to InZhbHVlIg==
com.orhanobut.benchmark D/HAWK: Hawk.put -> Serialized to java.lang.String##0V@InZhbHVlIg==
com.orhanobut.benchmark D/HAWK: Hawk.put -> Stored successfully
com.orhanobut.benchmark I/System.out: Hawk.put: 11ms
com.orhanobut.benchmark D/HAWK: Hawk.get -> key: key
com.orhanobut.benchmark D/HAWK: Hawk.get -> Fetched from storage : java.lang.String##0V@InZhbHVlIg==
com.orhanobut.benchmark D/HAWK: Hawk.get -> Deserialized
com.orhanobut.benchmark D/HAWK: Hawk.get -> Decrypted to : "value"
com.orhanobut.benchmark D/HAWK: Hawk.get -> Converted to : value
com.orhanobut.benchmark I/System.out: Hawk.get: 5ms
com.orhanobut.benchmark I/System.out: Hawk.count: 0ms
com.orhanobut.benchmark I/System.out: Hawk.count: 0ms
com.orhanobut.benchmark I/System.out: Hawk.count: 4ms
```